### PR TITLE
fix: Resolve Firebase Auth persistence and boolean type errors

### DIFF
--- a/src/services/firestore.ts
+++ b/src/services/firestore.ts
@@ -70,6 +70,7 @@ export const getLink = async (linkId: string): Promise<Link | null> => {
     return {
       id: docSnap.id,
       ...data,
+      isArchived: Boolean(data.isArchived), // Ensure boolean type
       createdAt: data.createdAt.toDate(),
     };
   }
@@ -113,6 +114,7 @@ export const getUserLinks = async (
     return {
       id: doc.id,
       ...data,
+      isArchived: Boolean(data.isArchived), // Ensure boolean type
       createdAt: data.createdAt.toDate(),
     };
   });
@@ -138,6 +140,7 @@ export const getLinksByTag = async (
     return {
       id: doc.id,
       ...data,
+      isArchived: Boolean(data.isArchived), // Ensure boolean type
       createdAt: data.createdAt.toDate(),
     };
   });
@@ -151,7 +154,14 @@ export const updateLink = async (
   updates: Partial<Omit<LinkDocument, 'userId' | 'createdAt'>>
 ): Promise<void> => {
   const docRef = doc(db, 'links', linkId);
-  await updateDoc(docRef, updates);
+
+  // Ensure isArchived is always a boolean if it's being updated
+  const sanitizedUpdates = { ...updates };
+  if ('isArchived' in sanitizedUpdates && sanitizedUpdates.isArchived !== undefined) {
+    sanitizedUpdates.isArchived = Boolean(sanitizedUpdates.isArchived);
+  }
+
+  await updateDoc(docRef, sanitizedUpdates);
 };
 
 /**


### PR DESCRIPTION
- Implement custom getReactNativePersistence for Firebase v12 compatibility
- Add AsyncStorage persistence to Firebase Auth to prevent memory-only storage
- Ensure isArchived field is always boolean type in all data operations
- Add type conversion in getLink, getUserLinks, getLinksByTag functions
- Sanitize isArchived in updateLink to prevent string-to-boolean errors

Fixes:
- Firebase Auth warning about missing AsyncStorage
- HostFunction error: "expected dynamic type 'boolean', but had type 'string'"

🤖 Generated with [Claude Code](https://claude.com/claude-code)