### PR TITLE
Add Gemini AI agent search feature

### DIFF
--- a/src/navigation/LinksNavigator.tsx
+++ b/src/navigation/LinksNavigator.tsx
@@ -5,6 +5,7 @@ import LinksListScreen from '../screens/links/LinksListScreen';
 import AddLinkScreen from '../screens/links/AddLinkScreen';
 import LinkDetailScreen from '../screens/links/LinkDetailScreen';
 import ArchivedLinksScreen from '../screens/links/ArchivedLinksScreen';
+import AgentSearchScreen from '../screens/search/AgentSearchScreen';
 
 const Stack = createNativeStackNavigator<LinksStackParamList>();
 
@@ -37,6 +38,13 @@ const LinksNavigator: React.FC = () => {
         component={ArchivedLinksScreen}
         options={{
           title: 'アーカイブ',
+        }}
+      />
+      <Stack.Screen
+        name="AgentSearch"
+        component={AgentSearchScreen}
+        options={{
+          title: 'AIエージェント検索',
         }}
       />
     </Stack.Navigator>

--- a/src/screens/links/LinksListScreen.tsx
+++ b/src/screens/links/LinksListScreen.tsx
@@ -20,6 +20,7 @@ import { Link } from '../../types';
 import { ERROR_MESSAGES, SUCCESS_MESSAGES } from '../../constants/messages';
 import QRCodeScanner from '../../components/links/QRCodeScanner';
 import NFCReader from '../../components/links/NFCReader';
+import { getGeminiApiKey } from '../../utils/storage';
 
 type LinksListScreenNavigationProp = NativeStackNavigationProp<
   LinksStackParamList,
@@ -40,6 +41,7 @@ const LinksListScreen: React.FC<Props> = ({ navigation }) => {
   const [showQRScanner, setShowQRScanner] = useState(false);
   const [showNFCReader, setShowNFCReader] = useState(false);
   const [fabAnimation] = useState(new Animated.Value(0));
+  const [hasGeminiApiKey, setHasGeminiApiKey] = useState(false);
 
   const loadLinks = async () => {
     if (!user) return;
@@ -58,12 +60,23 @@ const LinksListScreen: React.FC<Props> = ({ navigation }) => {
     }
   };
 
+  const checkGeminiApiKey = async () => {
+    try {
+      const apiKey = await getGeminiApiKey();
+      setHasGeminiApiKey(!!apiKey);
+    } catch (error) {
+      setHasGeminiApiKey(false);
+    }
+  };
+
   useEffect(() => {
     loadLinks();
+    checkGeminiApiKey();
 
     // 画面に戻ってきたときにリンクを再読み込み
     const unsubscribe = navigation.addListener('focus', () => {
       loadLinks();
+      checkGeminiApiKey();
     });
 
     return unsubscribe;
@@ -243,6 +256,19 @@ const LinksListScreen: React.FC<Props> = ({ navigation }) => {
           </TouchableOpacity>
         )}
       </View>
+
+      {/* AIエージェント検索ボタン */}
+      {hasGeminiApiKey && (
+        <View style={styles.agentSearchButtonContainer}>
+          <TouchableOpacity
+            style={styles.agentSearchButton}
+            onPress={() => navigation.navigate('AgentSearch')}
+          >
+            <Ionicons name="sparkles" size={18} color="#007AFF" />
+            <Text style={styles.agentSearchButtonText}>AIエージェント検索</Text>
+          </TouchableOpacity>
+        </View>
+      )}
 
       {links.length === 0 ? (
         <View style={styles.emptyContainer}>
@@ -458,6 +484,25 @@ const styles = StyleSheet.create({
   },
   clearButton: {
     padding: 4,
+  },
+  agentSearchButtonContainer: {
+    paddingHorizontal: 10,
+    paddingBottom: 5,
+  },
+  agentSearchButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#E3F2FD',
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+    borderRadius: 8,
+    gap: 6,
+  },
+  agentSearchButtonText: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#007AFF',
   },
   loadingContainer: {
     flex: 1,

--- a/src/screens/search/AgentSearchScreen.tsx
+++ b/src/screens/search/AgentSearchScreen.tsx
@@ -1,0 +1,517 @@
+import React, { useState, useEffect } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  StyleSheet,
+  ActivityIndicator,
+  Alert,
+  ScrollView,
+  SafeAreaView,
+  Linking,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { LinksStackParamList, Link } from '../../types';
+import { useAuth } from '../../contexts/AuthContext';
+import { getGeminiApiKey } from '../../utils/storage';
+import { searchWithAgent, getSearchQuerySuggestions } from '../../services/agentSearch';
+import { ERROR_MESSAGES } from '../../constants/messages';
+
+type AgentSearchScreenNavigationProp = NativeStackNavigationProp<
+  LinksStackParamList,
+  'AgentSearch'
+>;
+
+interface Props {
+  navigation: AgentSearchScreenNavigationProp;
+}
+
+const AgentSearchScreen: React.FC<Props> = ({ navigation }) => {
+  const { user } = useAuth();
+  const [hasApiKey, setHasApiKey] = useState(false);
+  const [checkingApiKey, setCheckingApiKey] = useState(true);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searching, setSearching] = useState(false);
+  const [searchResults, setSearchResults] = useState<Link[]>([]);
+  const [explanation, setExplanation] = useState('');
+  const [hasSearched, setHasSearched] = useState(false);
+
+  // Gemini APIキーの確認
+  useEffect(() => {
+    checkApiKey();
+  }, []);
+
+  const checkApiKey = async () => {
+    try {
+      const apiKey = await getGeminiApiKey();
+      setHasApiKey(!!apiKey);
+    } catch (error) {
+      setHasApiKey(false);
+    } finally {
+      setCheckingApiKey(false);
+    }
+  };
+
+  // 検索実行
+  const handleSearch = async () => {
+    if (!user) {
+      Alert.alert('エラー', 'ログインが必要です');
+      return;
+    }
+
+    if (!searchQuery.trim()) {
+      Alert.alert('エラー', '検索クエリを入力してください');
+      return;
+    }
+
+    setSearching(true);
+    setHasSearched(true);
+
+    try {
+      const apiKey = await getGeminiApiKey();
+      if (!apiKey) {
+        Alert.alert('エラー', 'Gemini APIキーが設定されていません');
+        return;
+      }
+
+      const result = await searchWithAgent(apiKey, user.uid, searchQuery);
+      setSearchResults(result.links);
+      setExplanation(result.explanation);
+    } catch (error: any) {
+      if (__DEV__) {
+        console.error('[AgentSearch] Error:', error);
+      }
+      Alert.alert('検索エラー', error.message || ERROR_MESSAGES.GEMINI.SUMMARY_FAILED);
+      setSearchResults([]);
+      setExplanation('');
+    } finally {
+      setSearching(false);
+    }
+  };
+
+  // クエリ提案をタップ
+  const handleSuggestionPress = (suggestion: string) => {
+    setSearchQuery(suggestion);
+  };
+
+  // リンクをタップ
+  const handleLinkPress = (link: Link) => {
+    navigation.navigate('LinkDetail', { linkId: link.id });
+  };
+
+  // URLを開く
+  const handleOpenUrl = async (url: string) => {
+    try {
+      const supported = await Linking.canOpenURL(url);
+      if (supported) {
+        await Linking.openURL(url);
+      } else {
+        Alert.alert('エラー', 'このURLを開けません');
+      }
+    } catch (error) {
+      Alert.alert('エラー', 'URLを開く際にエラーが発生しました');
+    }
+  };
+
+  // APIキーが設定されていない場合
+  if (checkingApiKey) {
+    return (
+      <View style={styles.centerContainer}>
+        <ActivityIndicator size="large" color="#007AFF" />
+        <Text style={styles.loadingText}>読み込み中...</Text>
+      </View>
+    );
+  }
+
+  if (!hasApiKey) {
+    return (
+      <SafeAreaView style={styles.container}>
+        <View style={styles.header}>
+          <Text style={styles.headerTitle}>AIエージェント検索</Text>
+        </View>
+        <View style={styles.centerContainer}>
+          <Ionicons name="key-outline" size={80} color="#ccc" />
+          <Text style={styles.noApiKeyTitle}>Gemini APIキーが必要です</Text>
+          <Text style={styles.noApiKeyDescription}>
+            AIエージェント検索を使用するには、設定画面でGemini APIキーを登録してください。
+          </Text>
+          <TouchableOpacity
+            style={styles.settingsButton}
+            onPress={() => navigation.navigate('LinksList')}
+          >
+            <Ionicons name="settings-outline" size={20} color="#fff" />
+            <Text style={styles.settingsButtonText}>設定画面へ</Text>
+          </TouchableOpacity>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  // メイン画面
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.header}>
+        <Text style={styles.headerTitle}>AIエージェント検索</Text>
+        <Text style={styles.headerSubtitle}>
+          ざっくりとした記憶からリンクを探せます
+        </Text>
+      </View>
+
+      <ScrollView style={styles.content} keyboardShouldPersistTaps="handled">
+        {/* 検索入力エリア */}
+        <View style={styles.searchSection}>
+          <View style={styles.searchInputContainer}>
+            <Ionicons
+              name="search-outline"
+              size={20}
+              color="#999"
+              style={styles.searchIcon}
+            />
+            <TextInput
+              style={styles.searchInput}
+              placeholder="例: 3月くらいにReactについて調べた気がする"
+              placeholderTextColor="#999"
+              value={searchQuery}
+              onChangeText={setSearchQuery}
+              multiline
+              numberOfLines={3}
+              textAlignVertical="top"
+            />
+          </View>
+          <TouchableOpacity
+            style={[styles.searchButton, searching && styles.searchButtonDisabled]}
+            onPress={handleSearch}
+            disabled={searching}
+          >
+            {searching ? (
+              <ActivityIndicator color="#fff" />
+            ) : (
+              <>
+                <Ionicons name="sparkles" size={20} color="#fff" />
+                <Text style={styles.searchButtonText}>検索</Text>
+              </>
+            )}
+          </TouchableOpacity>
+        </View>
+
+        {/* クエリ提案 */}
+        {!hasSearched && (
+          <View style={styles.suggestionsSection}>
+            <Text style={styles.suggestionsTitle}>検索例:</Text>
+            {getSearchQuerySuggestions().map((suggestion, index) => (
+              <TouchableOpacity
+                key={index}
+                style={styles.suggestionChip}
+                onPress={() => handleSuggestionPress(suggestion)}
+              >
+                <Text style={styles.suggestionText}>{suggestion}</Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+        )}
+
+        {/* 検索結果 */}
+        {hasSearched && (
+          <View style={styles.resultsSection}>
+            {/* エージェントの説明 */}
+            {explanation && (
+              <View style={styles.explanationContainer}>
+                <Ionicons name="information-circle" size={20} color="#007AFF" />
+                <Text style={styles.explanationText}>{explanation}</Text>
+              </View>
+            )}
+
+            {/* 結果リスト */}
+            {searchResults.length > 0 ? (
+              <View style={styles.resultsList}>
+                <Text style={styles.resultsHeader}>
+                  {searchResults.length}件のリンクが見つかりました
+                </Text>
+                {searchResults.map((link) => (
+                  <TouchableOpacity
+                    key={link.id}
+                    style={styles.linkCard}
+                    onPress={() => handleLinkPress(link)}
+                  >
+                    <View style={styles.linkHeader}>
+                      <Text style={styles.linkTitle} numberOfLines={2}>
+                        {link.title}
+                      </Text>
+                      <TouchableOpacity
+                        onPress={() => handleOpenUrl(link.url)}
+                        hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+                      >
+                        <Ionicons name="open-outline" size={20} color="#007AFF" />
+                      </TouchableOpacity>
+                    </View>
+                    <Text style={styles.linkUrl} numberOfLines={1}>
+                      {link.url}
+                    </Text>
+                    <View style={styles.linkMeta}>
+                      <Text style={styles.linkDate}>
+                        {new Date(link.createdAt).toLocaleDateString('ja-JP', {
+                          year: 'numeric',
+                          month: 'long',
+                          day: 'numeric',
+                        })}
+                      </Text>
+                      {link.tags.length > 0 && (
+                        <View style={styles.linkTags}>
+                          {link.tags.slice(0, 3).map((tag, index) => (
+                            <View key={index} style={styles.tag}>
+                              <Text style={styles.tagText}>{tag}</Text>
+                            </View>
+                          ))}
+                        </View>
+                      )}
+                    </View>
+                  </TouchableOpacity>
+                ))}
+              </View>
+            ) : (
+              <View style={styles.noResultsContainer}>
+                <Ionicons name="sad-outline" size={60} color="#ccc" />
+                <Text style={styles.noResultsText}>
+                  該当するリンクが見つかりませんでした
+                </Text>
+                <Text style={styles.noResultsHint}>
+                  別のキーワードで検索してみてください
+                </Text>
+              </View>
+            )}
+          </View>
+        )}
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f5f5f5',
+  },
+  centerContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 20,
+  },
+  header: {
+    backgroundColor: '#fff',
+    padding: 20,
+    borderBottomWidth: 1,
+    borderBottomColor: '#e0e0e0',
+  },
+  headerTitle: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    color: '#333',
+  },
+  headerSubtitle: {
+    fontSize: 14,
+    color: '#666',
+    marginTop: 4,
+  },
+  content: {
+    flex: 1,
+  },
+  loadingText: {
+    marginTop: 16,
+    fontSize: 16,
+    color: '#666',
+  },
+  noApiKeyTitle: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    color: '#333',
+    marginTop: 20,
+    textAlign: 'center',
+  },
+  noApiKeyDescription: {
+    fontSize: 14,
+    color: '#666',
+    marginTop: 12,
+    textAlign: 'center',
+    paddingHorizontal: 40,
+    lineHeight: 20,
+  },
+  settingsButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#007AFF',
+    paddingVertical: 12,
+    paddingHorizontal: 24,
+    borderRadius: 8,
+    marginTop: 24,
+  },
+  settingsButtonText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '600',
+    marginLeft: 8,
+  },
+  searchSection: {
+    padding: 16,
+    backgroundColor: '#fff',
+    marginBottom: 16,
+  },
+  searchInputContainer: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    backgroundColor: '#f5f5f5',
+    borderRadius: 12,
+    padding: 12,
+    marginBottom: 12,
+  },
+  searchIcon: {
+    marginTop: 2,
+    marginRight: 8,
+  },
+  searchInput: {
+    flex: 1,
+    fontSize: 16,
+    color: '#333',
+    minHeight: 60,
+  },
+  searchButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#007AFF',
+    paddingVertical: 14,
+    borderRadius: 12,
+    gap: 8,
+  },
+  searchButtonDisabled: {
+    backgroundColor: '#ccc',
+  },
+  searchButtonText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  suggestionsSection: {
+    padding: 16,
+    backgroundColor: '#fff',
+    marginBottom: 16,
+  },
+  suggestionsTitle: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#666',
+    marginBottom: 12,
+  },
+  suggestionChip: {
+    backgroundColor: '#f0f0f0',
+    paddingVertical: 8,
+    paddingHorizontal: 16,
+    borderRadius: 20,
+    marginBottom: 8,
+  },
+  suggestionText: {
+    fontSize: 14,
+    color: '#333',
+  },
+  resultsSection: {
+    flex: 1,
+  },
+  explanationContainer: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    backgroundColor: '#E3F2FD',
+    padding: 16,
+    marginHorizontal: 16,
+    marginBottom: 16,
+    borderRadius: 12,
+    gap: 12,
+  },
+  explanationText: {
+    flex: 1,
+    fontSize: 14,
+    color: '#0D47A1',
+    lineHeight: 20,
+  },
+  resultsList: {
+    paddingHorizontal: 16,
+    paddingBottom: 16,
+  },
+  resultsHeader: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#333',
+    marginBottom: 12,
+  },
+  linkCard: {
+    backgroundColor: '#fff',
+    padding: 16,
+    borderRadius: 12,
+    marginBottom: 12,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.1,
+    shadowRadius: 2,
+    elevation: 2,
+  },
+  linkHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    marginBottom: 8,
+  },
+  linkTitle: {
+    flex: 1,
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#333',
+    marginRight: 12,
+  },
+  linkUrl: {
+    fontSize: 13,
+    color: '#007AFF',
+    marginBottom: 8,
+  },
+  linkMeta: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  linkDate: {
+    fontSize: 12,
+    color: '#999',
+  },
+  linkTags: {
+    flexDirection: 'row',
+    gap: 6,
+  },
+  tag: {
+    backgroundColor: '#E3F2FD',
+    paddingVertical: 4,
+    paddingHorizontal: 8,
+    borderRadius: 12,
+  },
+  tagText: {
+    fontSize: 11,
+    color: '#0D47A1',
+  },
+  noResultsContainer: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 60,
+  },
+  noResultsText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#666',
+    marginTop: 16,
+  },
+  noResultsHint: {
+    fontSize: 14,
+    color: '#999',
+    marginTop: 8,
+  },
+});
+
+export default AgentSearchScreen;

--- a/src/services/agentSearch.ts
+++ b/src/services/agentSearch.ts
@@ -1,0 +1,139 @@
+import { GoogleGenerativeAI } from '@google/generative-ai';
+import { Link } from '../types';
+import { getUserLinks } from './firestore';
+import { ERROR_MESSAGES } from '../constants/messages';
+
+/**
+ * エージェント検索結果の型
+ */
+export interface AgentSearchResult {
+  links: Link[];
+  explanation: string;
+}
+
+/**
+ * Gemini AIエージェントを使って自然言語クエリでリンクを検索する
+ * @param apiKey ユーザーのGemini APIキー
+ * @param userId ユーザーID
+ * @param query 自然言語の検索クエリ（例: "3月くらいにReactについて調べた気がする"）
+ * @returns 検索結果とエージェントの説明
+ */
+export const searchWithAgent = async (
+  apiKey: string,
+  userId: string,
+  query: string
+): Promise<AgentSearchResult> => {
+  try {
+    if (!apiKey || apiKey.trim() === '') {
+      throw new Error('APIキーが設定されていません');
+    }
+
+    if (!query || query.trim() === '') {
+      throw new Error('検索クエリを入力してください');
+    }
+
+    // ユーザーのすべてのリンクを取得（アーカイブ含む）
+    const allLinks = await getUserLinks(userId, true);
+
+    if (allLinks.length === 0) {
+      return {
+        links: [],
+        explanation: '保存されているリンクがまだありません。',
+      };
+    }
+
+    // Gemini APIクライアントの初期化
+    const genAI = new GoogleGenerativeAI(apiKey);
+    const model = genAI.getGenerativeModel({ model: 'models/gemini-flash-latest' });
+
+    // リンクデータをJSON形式で整形
+    const linksData = allLinks.map((link, index) => ({
+      index,
+      id: link.id,
+      title: link.title,
+      url: link.url,
+      tags: link.tags,
+      createdAt: link.createdAt.toISOString(),
+      isArchived: link.isArchived,
+    }));
+
+    // プロンプトの作成
+    const prompt = `あなたは、ユーザーが保存したリンク集から関連する情報を検索するAIアシスタントです。
+
+ユーザーの検索クエリ:
+${query}
+
+ユーザーが保存しているリンク一覧（JSON形式）:
+${JSON.stringify(linksData, null, 2)}
+
+指示:
+1. ユーザーの検索クエリを分析し、関連性の高いリンクを見つけてください
+2. 日付の表現（"3月くらい"、"最近"、"去年"など）も考慮してください
+3. キーワードだけでなく、文脈や意図も理解してください
+4. 見つかったリンクのindexを配列で返してください
+5. 検索結果について日本語で簡潔な説明を付けてください
+
+回答は必ず以下のJSON形式で返してください:
+{
+  "matchedIndexes": [0, 3, 5],
+  "explanation": "◯月に保存された◯◯に関するリンクを◯件見つけました。"
+}
+
+見つからない場合は:
+{
+  "matchedIndexes": [],
+  "explanation": "該当するリンクが見つかりませんでした。"
+}`;
+
+    // エージェントに検索を依頼
+    const result = await model.generateContent(prompt);
+    const response = await result.response;
+    const responseText = response.text();
+
+    // JSON部分を抽出
+    const jsonMatch = responseText.match(/\{[\s\S]*\}/);
+    if (!jsonMatch) {
+      throw new Error('エージェントからの応答を解析できませんでした');
+    }
+
+    const parsedResponse = JSON.parse(jsonMatch[0]) as {
+      matchedIndexes: number[];
+      explanation: string;
+    };
+
+    // マッチしたリンクを取得
+    const matchedLinks = parsedResponse.matchedIndexes
+      .filter((index) => index >= 0 && index < allLinks.length)
+      .map((index) => allLinks[index]);
+
+    return {
+      links: matchedLinks,
+      explanation: parsedResponse.explanation || '検索が完了しました。',
+    };
+  } catch (error: any) {
+    if (__DEV__) {
+      console.error('[AgentSearch] Error:', error);
+    }
+
+    // JSONパースエラーの場合
+    if (error instanceof SyntaxError) {
+      throw new Error('検索結果の解析に失敗しました。もう一度お試しください。');
+    }
+
+    throw new Error(error.message || ERROR_MESSAGES.GEMINI.SUMMARY_FAILED);
+  }
+};
+
+/**
+ * 検索クエリの提案を生成
+ * @returns クエリの例の配列
+ */
+export const getSearchQuerySuggestions = (): string[] => {
+  return [
+    '3月くらいにReactについて調べた気がする',
+    '最近保存したデザインに関する記事',
+    '去年の夏にAIについて見たやつ',
+    'TypeScriptのチュートリアル',
+    'Node.jsの設定方法',
+  ];
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -89,6 +89,7 @@ export type LinksStackParamList = {
   AddLink: { initialUrl?: string } | undefined;
   LinkDetail: { linkId: string };
   ArchivedLinks: undefined;
+  AgentSearch: undefined;
 };
 
 export type TagsStackParamList = {


### PR DESCRIPTION
Implement natural language search functionality using Gemini API:
- Add agent search service to process natural language queries
- Create AgentSearchScreen with search UI and results display
- Show agent search button in LinksListScreen when API key is configured
- Update navigation types and routes to support new feature

Users can now search their saved links using casual queries like
"3月くらいにReactについて調べた気がする" instead of exact keywords.