### PR TITLE
Add dynamic agent tab visibility based on Gemini API key

### DIFF
--- a/src/contexts/ApiKeyContext.tsx
+++ b/src/contexts/ApiKeyContext.tsx
@@ -1,0 +1,64 @@
+import React, { createContext, useState, useContext, useEffect, ReactNode } from 'react';
+import { getGeminiApiKey, saveGeminiApiKey, removeGeminiApiKey } from '../utils/storage';
+
+interface ApiKeyContextType {
+  hasApiKey: boolean;
+  isLoading: boolean;
+  checkApiKey: () => Promise<void>;
+  saveApiKey: (apiKey: string) => Promise<void>;
+  deleteApiKey: () => Promise<void>;
+}
+
+const ApiKeyContext = createContext<ApiKeyContextType | undefined>(undefined);
+
+export const ApiKeyProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [hasApiKey, setHasApiKey] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const checkApiKey = async () => {
+    try {
+      const apiKey = await getGeminiApiKey();
+      setHasApiKey(!!apiKey);
+    } catch (error) {
+      setHasApiKey(false);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const saveApiKey = async (apiKey: string) => {
+    await saveGeminiApiKey(apiKey);
+    setHasApiKey(true);
+  };
+
+  const deleteApiKey = async () => {
+    await removeGeminiApiKey();
+    setHasApiKey(false);
+  };
+
+  useEffect(() => {
+    checkApiKey();
+  }, []);
+
+  return (
+    <ApiKeyContext.Provider
+      value={{
+        hasApiKey,
+        isLoading,
+        checkApiKey,
+        saveApiKey,
+        deleteApiKey,
+      }}
+    >
+      {children}
+    </ApiKeyContext.Provider>
+  );
+};
+
+export const useApiKey = () => {
+  const context = useContext(ApiKeyContext);
+  if (context === undefined) {
+    throw new Error('useApiKey must be used within an ApiKeyProvider');
+  }
+  return context;
+};

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { useAuth } from '../contexts/AuthContext';
+import { ApiKeyProvider } from '../contexts/ApiKeyContext';
 import AuthNavigator from './AuthNavigator';
 import MainNavigator from './MainNavigator';
 import SharedURLHandler from '../components/SharedURLHandler';
@@ -22,16 +23,18 @@ const AppNavigator: React.FC = () => {
   }
 
   return (
-    <NavigationContainer>
-      {user && <SharedURLHandler />}
-      <Stack.Navigator screenOptions={{ headerShown: false }}>
-        {user ? (
-          <Stack.Screen name="Main" component={MainNavigator} />
-        ) : (
-          <Stack.Screen name="Auth" component={AuthNavigator} />
-        )}
-      </Stack.Navigator>
-    </NavigationContainer>
+    <ApiKeyProvider>
+      <NavigationContainer>
+        {user && <SharedURLHandler />}
+        <Stack.Navigator screenOptions={{ headerShown: false }}>
+          {user ? (
+            <Stack.Screen name="Main" component={MainNavigator} />
+          ) : (
+            <Stack.Screen name="Auth" component={AuthNavigator} />
+          )}
+        </Stack.Navigator>
+      </NavigationContainer>
+    </ApiKeyProvider>
   );
 };
 

--- a/src/navigation/MainNavigator.tsx
+++ b/src/navigation/MainNavigator.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { Ionicons } from '@expo/vector-icons';
 import { MainTabParamList } from '../types';
@@ -6,25 +6,12 @@ import LinksNavigator from './LinksNavigator';
 import TagsNavigator from './TagsNavigator';
 import AgentNavigator from './AgentNavigator';
 import SettingsNavigator from './SettingsNavigator';
-import { getGeminiApiKey } from '../utils/storage';
+import { useApiKey } from '../contexts/ApiKeyContext';
 
 const Tab = createBottomTabNavigator<MainTabParamList>();
 
 const MainNavigator: React.FC = () => {
-  const [hasApiKey, setHasApiKey] = useState(false);
-
-  useEffect(() => {
-    checkApiKey();
-  }, []);
-
-  const checkApiKey = async () => {
-    try {
-      const apiKey = await getGeminiApiKey();
-      setHasApiKey(!!apiKey);
-    } catch (error) {
-      setHasApiKey(false);
-    }
-  };
+  const { hasApiKey } = useApiKey();
 
   return (
     <Tab.Navigator

--- a/src/screens/settings/SettingsScreen.tsx
+++ b/src/screens/settings/SettingsScreen.tsx
@@ -14,33 +14,15 @@ import {
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
 import { useAuth } from '../../contexts/AuthContext';
-import { saveGeminiApiKey, getGeminiApiKey, removeGeminiApiKey } from '../../utils/storage';
+import { useApiKey } from '../../contexts/ApiKeyContext';
 import { validateApiKey } from '../../services/gemini';
 
 const SettingsScreen: React.FC = () => {
   const { user, logout } = useAuth();
   const navigation = useNavigation();
+  const { hasApiKey, isLoading, saveApiKey, deleteApiKey } = useApiKey();
   const [geminiApiKey, setGeminiApiKey] = useState('');
   const [isSaving, setIsSaving] = useState(false);
-  const [isLoading, setIsLoading] = useState(true);
-  const [hasApiKey, setHasApiKey] = useState(false);
-
-  useEffect(() => {
-    loadApiKey();
-  }, []);
-
-  const loadApiKey = async () => {
-    try {
-      const savedKey = await getGeminiApiKey();
-      if (savedKey) {
-        setHasApiKey(true);
-      }
-    } catch (error) {
-      console.error('Error loading API key:', error);
-    } finally {
-      setIsLoading(false);
-    }
-  };
 
   const handleSaveApiKey = async () => {
     if (!geminiApiKey.trim()) {
@@ -59,9 +41,8 @@ const SettingsScreen: React.FC = () => {
         return;
       }
 
-      // AsyncStorageに保存
-      await saveGeminiApiKey(geminiApiKey.trim());
-      setHasApiKey(true);
+      // Contextを使って保存（自動的にhasApiKeyが更新される）
+      await saveApiKey(geminiApiKey.trim());
       setGeminiApiKey('');
       Alert.alert('成功', 'APIキーを保存しました');
     } catch (error: any) {
@@ -83,8 +64,8 @@ const SettingsScreen: React.FC = () => {
           style: 'destructive',
           onPress: async () => {
             try {
-              await removeGeminiApiKey();
-              setHasApiKey(false);
+              // Contextを使って削除（自動的にhasApiKeyが更新される）
+              await deleteApiKey();
               setGeminiApiKey('');
               Alert.alert('成功', 'APIキーを削除しました');
             } catch (error) {


### PR DESCRIPTION
- Create ApiKeyContext to manage API key state globally
- Update AppNavigator to provide ApiKeyContext
- Update MainNavigator to use useApiKey hook for dynamic tab rendering
- Update SettingsScreen to update context when API key is saved/deleted
- Agent tab now automatically shows when API key is set and hides when deleted