### PR TITLE
リンク詳細画面のタグをタップ可能にし、タグリンク画面に遷移する機能を追加

### DIFF
--- a/src/screens/links/LinkDetailScreen.tsx
+++ b/src/screens/links/LinkDetailScreen.tsx
@@ -443,9 +443,18 @@ const LinkDetailScreen: React.FC<Props> = ({ navigation, route }) => {
           {link.tags.length > 0 ? (
             <View style={styles.tags}>
               {link.tags.map((tag, index) => (
-                <View key={index} style={styles.tag}>
+                <TouchableOpacity
+                  key={index}
+                  style={styles.tag}
+                  onPress={() => {
+                    (navigation as any).navigate('Tags', {
+                      screen: 'TagLinks',
+                      params: { tagName: tag },
+                    });
+                  }}
+                >
                   <Text style={styles.tagText}>{tag}</Text>
-                </View>
+                </TouchableOpacity>
               ))}
             </View>
           ) : (


### PR DESCRIPTION
## Summary
- リンク詳細画面でタグをタップしたときに、そのタグのリンク一覧画面（TagLinksScreen）に遷移する機能を実装しました
- タグ表示を `View` から `TouchableOpacity` に変更し、タップ可能にしました
- クロススタックナビゲーションを使用して、LinksスタックからTagsスタックへスムーズに遷移できるようにしました

## 変更内容
- `src/screens/links/LinkDetailScreen.tsx`: タグ表示コンポーネントを `TouchableOpacity` に変更し、`onPress` ハンドラーでナビゲーション処理を追加

## Test plan
- [ ] リンク詳細画面でタグが表示されることを確認
- [ ] タグをタップしたときに、タグリンク画面に正しく遷移することを確認
- [ ] 複数のタグがある場合、それぞれ正しいタグのリンク一覧が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)