### PR TITLE
feat: LinkDetailでアプリ内ブラウザ表示を追加

### DIFF
--- a/src/screens/links/LinkDetailScreen.tsx
+++ b/src/screens/links/LinkDetailScreen.tsx
@@ -14,6 +14,7 @@ import {
   KeyboardAvoidingView,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
+import * as WebBrowser from 'expo-web-browser';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RouteProp } from '@react-navigation/native';
 import { LinksStackParamList, Link, Tag } from '../../types';
@@ -106,6 +107,21 @@ const LinkDetailScreen: React.FC<Props> = ({ navigation, route }) => {
         alert('エラー: URLを開く際にエラーが発生しました');
       } else {
         showError('エラー', 'URLを開く際にエラーが発生しました');
+      }
+    }
+  };
+
+  const handleOpenInAppBrowser = async () => {
+    if (!link) return;
+
+    try {
+      await WebBrowser.openBrowserAsync(link.url);
+    } catch (error) {
+      console.error('Error opening in-app browser:', error);
+      if (Platform.OS === 'web') {
+        alert('エラー: アプリ内ブラウザで開けませんでした');
+      } else {
+        showError('エラー', 'アプリ内ブラウザで開けませんでした');
       }
     }
   };
@@ -468,6 +484,14 @@ const LinkDetailScreen: React.FC<Props> = ({ navigation, route }) => {
         >
           <Ionicons name="open-outline" size={20} color="#FFFFFF" style={{ marginRight: 8 }} />
           <Text style={styles.openLinkButtonText}>リンクを開く</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={styles.openLinkButton}
+          onPress={handleOpenInAppBrowser}
+        >
+          <Ionicons name="globe-outline" size={20} color="#FFFFFF" style={{ marginRight: 8 }} />
+          <Text style={styles.openLinkButtonText}>アプリ内ブラウザで開く</Text>
         </TouchableOpacity>
 
         <TouchableOpacity


### PR DESCRIPTION
## 概要\n- LinkDetail画面に`アプリ内ブラウザで開く`ボタンを追加\n- `expo-web-browser` を使ってリンクをアプリ内ブラウザで表示\n- 既存の日本語UIテキストとボタンスタイルに合わせた実装\n\n## 変更ファイル\n- src/screens/links/LinkDetailScreen.tsx\n\n## 確認\n- ローカル実行可能な自動チェックは未実行（依存未インストールのため`tsc`実行不可）\n\n## レビュー方針\n- Human review required\n- No auto-merge\n